### PR TITLE
feature: Add getters and fqdn required by data lineage

### DIFF
--- a/dbcat/__main__.py
+++ b/dbcat/__main__.py
@@ -9,7 +9,7 @@ import yaml
 
 from dbcat import __version__, pull
 from dbcat.catalog.metadata import Connection
-from dbcat.catalog.orm import Connection as CatConnection
+from dbcat.catalog.orm import Catalog as CatConnection
 from dbcat.log_mixin import LogMixin
 
 

--- a/dbcat/catalog/orm.py
+++ b/dbcat/catalog/orm.py
@@ -1,4 +1,5 @@
 from contextlib import closing
+from typing import Tuple
 
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.exc import IntegrityError
@@ -11,7 +12,86 @@ from dbcat.catalog.metadata import Database
 Base: DeclarativeMeta = declarative_base()
 
 
-class Connection:
+class CatDatabase(Base):
+    __tablename__ = "databases"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    schemata = relationship("CatSchema", back_populates="database")
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @property
+    def fqdn(self):
+        return self.name
+
+
+class CatSchema(Base):
+    __tablename__ = "schemata"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    database_id = Column(Integer, ForeignKey("databases.id"))
+    database = relationship("CatDatabase", back_populates="schemata", lazy="joined")
+    tables = relationship("CatTable", back_populates="schema")
+
+    def __init__(self, name: str, database: CatDatabase):
+        self.name = name
+        self.database = database
+
+    @property
+    def fqdn(self):
+        return self.database.name, self.name
+
+
+class CatTable(Base):
+    __tablename__ = "tables"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    schema_id = Column(Integer, ForeignKey("schemata.id"))
+    schema = relationship("CatSchema", back_populates="tables", lazy="joined")
+    columns = relationship(
+        "CatColumn", back_populates="table", order_by="CatColumn.sort_order"
+    )
+
+    def __init__(self, name: str, schema: CatSchema):
+        self.name = name
+        self.schema = schema
+
+    @property
+    def fqdn(self):
+        return self.schema.database.name, self.schema.name, self.name
+
+
+class CatColumn(Base):
+    __tablename__ = "columns"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    type = Column(String)
+    sort_order = Column(Integer)
+    table_id = Column(Integer, ForeignKey("tables.id"))
+    table = relationship("CatTable", back_populates="columns", lazy="joined")
+
+    def __init__(self, name: str, type: str, sort_order: int, table: CatTable):
+        self.name = name
+        self.type = type
+        self.sort_order = sort_order
+        self.table = table
+
+    @property
+    def fqdn(self):
+        return (
+            self.table.schema.database.name,
+            self.table.schema.name,
+            self.table.name,
+            self.name,
+        )
+
+
+class Catalog:
     def __init__(
         self,
         type: str,
@@ -74,6 +154,50 @@ class Connection:
             except IntegrityError:
                 return session.query(model).filter_by(**kwargs).one(), True
 
+    def get_database(self, database_name: str) -> CatDatabase:
+        with closing(self.session) as session:
+            return (
+                session.query(CatDatabase)
+                .filter(CatDatabase.name == database_name)
+                .one()
+            )
+
+    def get_schema(self, schema_name: Tuple) -> CatSchema:
+        with closing(self.session) as session:
+            return (
+                session.query(CatSchema)
+                .join(CatSchema.database)
+                .filter(CatDatabase.name == schema_name[0])
+                .filter(CatSchema.name == schema_name[1])
+                .one()
+            )
+
+    def get_table(self, table_name: Tuple) -> CatTable:
+        with closing(self.session) as session:
+            return (
+                session.query(CatTable)
+                .join(CatTable.schema)
+                .join(CatSchema.database)
+                .filter(CatDatabase.name == table_name[0])
+                .filter(CatSchema.name == table_name[1])
+                .filter(CatTable.name == table_name[2])
+                .one()
+            )
+
+    def get_column(self, column_name: Tuple) -> CatColumn:
+        with closing(self.session) as session:
+            return (
+                session.query(CatColumn)
+                .join(CatColumn.table)
+                .join(CatTable.schema)
+                .join(CatSchema.database)
+                .filter(CatDatabase.name == column_name[0])
+                .filter(CatSchema.name == column_name[1])
+                .filter(CatTable.name == column_name[2])
+                .filter(CatColumn.name == column_name[3])
+                .one()
+            )
+
     def save_catalog(self, database: Database) -> None:
         with closing(self.session) as session:
             db, db_found = self._get_one_or_create(
@@ -101,61 +225,3 @@ class Connection:
                             cc.type = c.type
                         index += 1
             session.commit()
-
-
-class CatDatabase(Base):
-    __tablename__ = "databases"
-
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    schemata = relationship("CatSchema", back_populates="database")
-
-    def __init__(self, name: str):
-        self.name = name
-
-
-class CatSchema(Base):
-    __tablename__ = "schemata"
-
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    database_id = Column(Integer, ForeignKey("databases.id"))
-    database = relationship("CatDatabase", back_populates="schemata")
-    tables = relationship("CatTable", back_populates="schema")
-
-    def __init__(self, name: str, database: CatDatabase):
-        self.name = name
-        self.database = database
-
-
-class CatTable(Base):
-    __tablename__ = "tables"
-
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    schema_id = Column(Integer, ForeignKey("schemata.id"))
-    schema = relationship("CatSchema", back_populates="tables")
-    columns = relationship(
-        "CatColumn", back_populates="table", order_by="CatColumn.sort_order"
-    )
-
-    def __init__(self, name: str, schema: CatSchema):
-        self.name = name
-        self.schema = schema
-
-
-class CatColumn(Base):
-    __tablename__ = "columns"
-
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    type = Column(String)
-    sort_order = Column(Integer)
-    table_id = Column(Integer, ForeignKey("tables.id"))
-    table = relationship("CatTable", back_populates="columns")
-
-    def __init__(self, name: str, type: str, sort_order: int, table: CatTable):
-        self.name = name
-        self.type = type
-        self.sort_order = sort_order
-        self.table = table

--- a/dbcat/dbcat.py
+++ b/dbcat/dbcat.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from dbcat.catalog.metadata import Connection
-from dbcat.catalog.orm import Connection as CatConnection
+from dbcat.catalog.orm import Catalog as CatConnection
 from dbcat.log_mixin import LogMixin
 from dbcat.scanners.db import DbScanner
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from dbcat.catalog.metadata import Connection as DbConnection
-from dbcat.catalog.orm import Connection
+from dbcat.catalog.orm import Catalog
 
 postgres_conf = """
 catalog:
@@ -22,7 +22,7 @@ catalog:
 @pytest.fixture
 def root_connection():
     config = yaml.safe_load(postgres_conf)
-    with closing(Connection(**config["catalog"])) as conn:
+    with closing(Catalog(**config["catalog"])) as conn:
         yield conn
 
 
@@ -63,7 +63,7 @@ catalog:
 @pytest.fixture
 def catalog_connection(setup_catalog):
     config = yaml.safe_load(catalog_conf)
-    with closing(Connection(**config["catalog"])) as conn:
+    with closing(Catalog(**config["catalog"])) as conn:
         yield conn
 
 

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -2,7 +2,7 @@ from contextlib import closing
 
 import pytest
 
-from dbcat.catalog.orm import CatColumn, CatDatabase, CatSchema, CatTable, Connection
+from dbcat.catalog.orm import Catalog, CatColumn, CatDatabase, CatSchema, CatTable
 from dbcat.scanners.json import File
 
 
@@ -23,7 +23,7 @@ def test_file_scanner(load_catalog):
 
 
 def test_catalog_config(root_connection):
-    conn: Connection = root_connection
+    conn: Catalog = root_connection
     assert conn.type == "postgres"
     assert conn.user == "piiuser"
     assert conn.password == "p11secret"
@@ -37,7 +37,7 @@ def test_sqlalchemy_root(root_connection):
         conn.execute("select 1")
 
 
-def test_catalog_tables(catalog_connection: Connection):
+def test_catalog_tables(catalog_connection: Catalog):
     session = catalog_connection.session
     try:
         assert len(session.query(CatDatabase).all()) == 0
@@ -140,3 +140,27 @@ def test_update_catalog(save_catalog):
         )
 
         assert group_col.type == "BIGINT"
+
+
+def test_get_database(save_catalog):
+    catalog, connection = save_catalog
+    database = connection.get_database("test")
+    assert database.fqdn == "test"
+
+
+def test_get_schema(save_catalog):
+    catalog, connection = save_catalog
+    schema = connection.get_schema(("test", "default"))
+    assert schema.fqdn == ("test", "default")
+
+
+def test_get_table(save_catalog):
+    catalog, connection = save_catalog
+    table = connection.get_table(("test", "default", "page"))
+    assert table.fqdn == ("test", "default", "page")
+
+
+def test_get_column(save_catalog):
+    catalog, connection = save_catalog
+    column = connection.get_column(("test", "default", "page", "page_title"))
+    assert column.fqdn == ("test", "default", "page", "page_title")

--- a/test/test_dbcat.py
+++ b/test/test_dbcat.py
@@ -5,7 +5,7 @@ import yaml
 
 from dbcat import pull
 from dbcat.catalog.metadata import Connection
-from dbcat.catalog.orm import Connection as CatConnection
+from dbcat.catalog.orm import Catalog as CatConnection
 
 conf = """
 catalog:


### PR DESCRIPTION
Rename orm.Connection to Catalog.
Add getters for all objects.
All parent objects are eagerly loaded.
Add a fqdn fn to get the full path name.