### PR TITLE
fix: Rename orm to modules.

### DIFF
--- a/dbcat/__init__.py
+++ b/dbcat/__init__.py
@@ -2,4 +2,12 @@
 
 __version__ = "0.3.3"
 
+import yaml
+
+from dbcat.catalog import Catalog
 from dbcat.dbcat import pull  # type: ignore
+
+
+def catalog_connection(config: str) -> Catalog:
+    config_yaml = yaml.safe_load(config)
+    return Catalog(**config_yaml["catalog"])

--- a/dbcat/catalog/__init__.py
+++ b/dbcat/catalog/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+
+from .catalog import Catalog
+from .models import CatColumn, CatSchema, CatSource, CatTable, ColumnLineage

--- a/dbcat/catalog/db.py
+++ b/dbcat/catalog/db.py
@@ -20,7 +20,7 @@ from databuilder.models.table_metadata import TableMetadata
 from pyhocon import ConfigFactory, ConfigTree
 
 from dbcat.catalog.catalog import Catalog
-from dbcat.catalog.orm import CatSource
+from dbcat.catalog.models import CatSource
 from dbcat.log_mixin import LogMixin
 
 

--- a/dbcat/catalog/models.py
+++ b/dbcat/catalog/models.py
@@ -231,7 +231,7 @@ class CatColumn(Base):
                 self.sort_order,
             ],
             [
-                other.table.schema.database.name,
+                other.table.schema.source.name,
                 other.table.schema.name,
                 other.table.name,
                 other.sort_order,
@@ -256,13 +256,19 @@ class ColumnLineage(Base):
 
     source_id = Column(Integer, ForeignKey("columns.id"))
     target_id = Column(Integer, ForeignKey("columns.id"))
+    job_id = Column(String)
     source = relationship("CatColumn", foreign_keys=source_id, lazy="joined")
     target = relationship("CatColumn", foreign_keys=target_id, lazy="joined")
 
-    def __init__(self, source: CatColumn, target: CatColumn, payload: Dict[Any, Any]):
-        self.source = source
-        self.target = target
+    def __init__(
+        self, source_id: int, target_id: int, job_id: str, payload: Dict[Any, Any]
+    ):
+        self.source_id = source_id
+        self.target_id = target_id
+        self.job_id = job_id
         self.payload = payload
 
     def __repr__(self):
-        return "<Edge: {} -{}-> {}>".format(self.source, self.target, self.payload)
+        return "<Edge: {} -> {} by {}. payload: {}>".format(
+            self.source, self.target, self.job_id, self.payload
+        )

--- a/dbcat/dbcat.py
+++ b/dbcat/dbcat.py
@@ -1,13 +1,6 @@
-import yaml
-
 from dbcat.catalog.catalog import Catalog
 from dbcat.catalog.db import DbScanner
 from dbcat.log_mixin import LogMixin
-
-
-def catalog_connection(config: str) -> Catalog:
-    config_yaml = yaml.safe_load(config)
-    return Catalog(**config_yaml["catalog"])
 
 
 def pull(catalog: Catalog) -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,8 +5,8 @@ import pymysql
 import pytest
 import yaml
 
+from dbcat import catalog_connection
 from dbcat.catalog.catalog import Catalog
-from dbcat.dbcat import catalog_connection
 
 postgres_conf = """
 catalog:

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -4,7 +4,13 @@ import pytest
 import yaml
 
 from dbcat.catalog.catalog import Catalog
-from dbcat.catalog.orm import CatColumn, CatSchema, CatSource, CatTable, ColumnLineage
+from dbcat.catalog.models import (
+    CatColumn,
+    CatSchema,
+    CatSource,
+    CatTable,
+    ColumnLineage,
+)
 
 
 class File:
@@ -378,7 +384,7 @@ def test_add_edge(save_catalog):
                 column_name=edge[1][3],
             )
 
-            catalog.add_column_lineage(source, target, {})
+            catalog.add_column_lineage(source, target, "test_add_edge", {})
 
     with closing(catalog.session) as session:
         all_edges = session.query(ColumnLineage).all()

--- a/test/test_dbcat.py
+++ b/test/test_dbcat.py
@@ -3,7 +3,7 @@ from contextlib import closing
 import pytest
 
 from dbcat import pull
-from dbcat.catalog.orm import CatSource
+from dbcat.catalog.models import CatSource
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Rename orm package to modules.
Move catalog_connection to init so that import is easier.
Add a job_id field in preparation for adding job model.