### PR TITLE
fix: Improve management and API of managed_session context manager

### DIFF
--- a/dbcat/__main__.py
+++ b/dbcat/__main__.py
@@ -149,6 +149,7 @@ def pull_cli(
 
     catalog_obj = catalog_connection(config)
     try:
+        init_db(catalog_obj)
         add_connections(catalog_obj, config)
         if len(connection_names) == 0:
             pull_all(catalog_obj)

--- a/dbcat/alembic.ini
+++ b/dbcat/alembic.ini
@@ -39,7 +39,7 @@ prepend_sys_path = .
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://catalog_user:catal0g_passw0rd@localhost/tokern
+sqlalchemy.url = driver://user:pass@localhost/dbname
 
 
 [post_write_hooks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbcat"
-version = "0.6.0"
+version = "0.6.1"
 description = "Tokern Data Catalog"
 authors = ["Tokern <info@tokern.io>"]
 license = "MIT"

--- a/test/test_dbcat.py
+++ b/test/test_dbcat.py
@@ -7,42 +7,44 @@ from dbcat.catalog.models import CatSource
 @pytest.fixture(scope="module")
 def setup_catalog_and_data(load_all_data, open_catalog_connection):
     catalog = open_catalog_connection
-    catalog.add_source(
-        name="mysql",
-        source_type="mysql",
-        uri="127.0.0.1",
-        username="piiuser",
-        password="p11secret",
-        database="piidb",
-    )
-    catalog.add_source(
-        name="pg",
-        source_type="postgresql",
-        uri="127.0.0.1",
-        username="piiuser",
-        password="p11secret",
-        database="piidb",
-        cluster="public",
-    )
+    with catalog.managed_session:
+        catalog.add_source(
+            name="mysql",
+            source_type="mysql",
+            uri="127.0.0.1",
+            username="piiuser",
+            password="p11secret",
+            database="piidb",
+        )
+        catalog.add_source(
+            name="pg",
+            source_type="postgresql",
+            uri="127.0.0.1",
+            username="piiuser",
+            password="p11secret",
+            database="piidb",
+            cluster="public",
+        )
     yield catalog
-    session = catalog.scoped_session
-    [session.delete(db) for db in session.query(CatSource).all()]
+    with catalog.managed_session as session:
+        [session.delete(db) for db in session.query(CatSource).all()]
 
 
 def run_asserts(catalog, connection_name):
-    pg_source = catalog.get_source(connection_name)
-    assert pg_source is not None
+    with catalog.managed_session:
+        pg_source = catalog.get_source(connection_name)
+        assert pg_source is not None
 
-    pg_schemata = pg_source.schemata
-    assert len(pg_schemata) == 1
+        pg_schemata = pg_source.schemata
+        assert len(pg_schemata) == 1
 
-    pg_tables = pg_schemata[0].tables
-    assert len(pg_tables) == 3
+        pg_tables = pg_schemata[0].tables
+        assert len(pg_tables) == 3
 
-    pg_columns = []
-    for table in pg_tables:
-        pg_columns = pg_columns + table.columns
-    assert len(pg_columns) == 6
+        pg_columns = []
+        for table in pg_tables:
+            pg_columns = pg_columns + table.columns
+        assert len(pg_columns) == 6
 
 
 def test_pull_all(setup_catalog_and_data):


### PR DESCRIPTION
Remove nested context manager. This is not required.
Make context manager re-entrant.
All functions in the catalog, assume that the context manager has been
entered. This simplifies the code dramatically.

Alembic migrations now accepts an engine so that it can be used as a
library in other applications.