### PR TITLE
fix: Fix Athena connection string to not set schema name

### DIFF
--- a/dbcat/__init__.py
+++ b/dbcat/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"

--- a/dbcat/catalog/models.py
+++ b/dbcat/catalog/models.py
@@ -137,7 +137,7 @@ class CatSource(BaseModel):
         elif self.source_type == "athena":
             conn_string = (
                 "awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/"
-                "{schema_name}?s3_staging_dir={s3_staging_dir}".format(
+                "?s3_staging_dir={s3_staging_dir}".format(
                     aws_access_key_id=quote_plus(self.aws_access_key_id)
                     if self.aws_access_key_id is not None
                     else "",
@@ -145,7 +145,6 @@ class CatSource(BaseModel):
                     if self.aws_secret_access_key is not None
                     else "",
                     region_name=self.region_name,
-                    schema_name=self.database,
                     s3_staging_dir=quote_plus(self.s3_staging_dir),
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbcat"
-version = "0.10.4"
+version = "0.10.5"
 description = "Tokern Data Catalog"
 authors = ["Tokern <info@tokern.io>"]
 license = "MIT"

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -42,7 +42,6 @@ def test_athena_extractor(open_catalog_connection):
             aws_access_key_id="access_key",
             aws_secret_access_key="secret_key",
             region_name="us_east_1",
-            database="db",
             s3_staging_dir="staging_dir",
         )
 
@@ -53,7 +52,7 @@ def test_athena_extractor(open_catalog_connection):
         )
         assert (
             scoped.get_string(SQLAlchemyExtractor.CONN_STRING)
-            == "awsathena+rest://access_key:secret_key@athena.us_east_1.amazonaws.com:443/db?s3_staging_dir=staging_dir"
+            == "awsathena+rest://access_key:secret_key@athena.us_east_1.amazonaws.com:443/?s3_staging_dir=staging_dir"
         )
 
 
@@ -64,7 +63,6 @@ def test_athena_extractor_iam(open_catalog_connection):
             name="athena_iam",
             source_type="athena",
             region_name="us_east_1",
-            database="db",
             s3_staging_dir="staging_dir",
         )
 
@@ -75,7 +73,7 @@ def test_athena_extractor_iam(open_catalog_connection):
         )
         assert (
             scoped.get_string(SQLAlchemyExtractor.CONN_STRING)
-            == "awsathena+rest://:@athena.us_east_1.amazonaws.com:443/db?s3_staging_dir=staging_dir"
+            == "awsathena+rest://:@athena.us_east_1.amazonaws.com:443/?s3_staging_dir=staging_dir"
         )
 
 


### PR DESCRIPTION
Related to https://github.com/tokern/piicatcher/issues/155

and https://github.com/tokern/piicatcher/issues/153