### PR TITLE
Added sqlserver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ The following databases are supported:
 * BigQuery
 * Snowflake
 * AWS Athena
+* SQLServer
 

--- a/dbcat/api.py
+++ b/dbcat/api.py
@@ -51,7 +51,11 @@ def catalog_connection(
     ):
         LOGGER.info(f"Open PG Catalog at {host}")
         return PGCatalog(
-            host=host, port=port, user=user, password=password, database=database,
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
         )
     elif path is not None:
         LOGGER.info(f"Open Sqlite Catalog at {path}")
@@ -143,7 +147,9 @@ def scan_sources(
 
 
 def add_sqlite_source(
-    catalog: Catalog, name: str, path: Path,
+    catalog: Catalog,
+    name: str,
+    path: Path,
 ):
     with catalog.managed_session:
         catalog.add_source(name=name, uri=str(path), source_type="sqlite")
@@ -252,30 +258,32 @@ def add_athena_source(
             aws_secret_access_key=aws_secret_access_key,
             region_name=region_name,
             s3_staging_dir=s3_staging_dir,
-            mfa = mfa,
+            mfa=mfa,
             aws_session_token=aws_session_token,
             source_type="athena",
         )
 
+
 def add_bigquery_source(
     catalog: Catalog,
     name: str,
-    username:str,
+    username: str,
     project_id: str,
     key_path: str,
 ) -> CatSource:
     with catalog.commit_context:
-            return catalog.add_source(
-                name=name,
-                username=username,
-                project_id = project_id,
-                key_path=key_path,
-                source_type="bigquery",
-            )
+        return catalog.add_source(
+            name=name,
+            username=username,
+            project_id=project_id,
+            key_path=key_path,
+            source_type="bigquery",
+        )
+
 
 def add_oracle_source(
     catalog: Catalog,
-    name: str, 
+    name: str,
     username: str,
     password: str,
     service_name: str,
@@ -291,4 +299,25 @@ def add_oracle_source(
             uri=uri,
             port=port,
             source_type="oracle",
+        )
+
+
+def add_sqlserver_source(
+    catalog: Catalog,
+    name: str,
+    username: str,
+    password: str,
+    database: str,
+    uri: str,
+    port: Optional[int] = None,
+) -> CatSource:
+    with catalog.commit_context:
+        return catalog.add_source(
+            name=name,
+            username=username,
+            password=password,
+            uri=uri,
+            port=port,
+            database=database,
+            source_type="sqlserver",
         )

--- a/dbcat/catalog/models.py
+++ b/dbcat/catalog/models.py
@@ -172,13 +172,16 @@ class CatSource(BaseModel):
                     aws_session_token=quote_plus(self.aws_session_token)
                     if self.aws_session_token is not None
                     else "",
-                    mfa=quote_plus(self.mfa)
-                    if self.mfa is not None
-                    else "",
+                    mfa=quote_plus(self.mfa) if self.mfa is not None else "",
                 )
             )
         elif self.source_type == "oracle":
             conn_string = f"oracle+cx_oracle://{self.username}:{self.password}@{self.uri}:{self.port}/{self.service_name}"
+        elif self.source_type == "sqlserver":
+            conn_string = (
+                f"mssql+pyodbc://{self.username}:{self.password}@{self.uri}/{self.database}"
+                + (f":{self.port}" if self.port else "")
+            )
         else:
             username_password_placeholder = (
                 f"{self.username}:{self.password}" if self.password is not None else ""

--- a/test/connections.yaml
+++ b/test/connections.yaml
@@ -41,3 +41,10 @@ connections:
     password: db_password
     port: db_port
     uri: db_uri
+  - name: sqlserver
+    source_type: sqlserver
+    username: db_user
+    password: db_password
+    uri: db_uri
+    database: db_database
+    port: db_port

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -445,7 +445,7 @@ def test_add_sources(open_catalog_connection):
             catalog.add_source(**c)
 
         connections = catalog.search_sources(source_like="%")
-        assert len(connections) == 8
+        assert len(connections) == 9
 
         # pg
         pg_connection = connections[1]
@@ -510,6 +510,16 @@ def test_add_sources(open_catalog_connection):
         assert oracle_conn.password == "db_password"
         assert oracle_conn.port == "db_port"
         assert oracle_conn.uri == "db_uri"
+
+        # sqlserver
+        sqlserver_conn = connections[8]
+        assert sqlserver_conn.name == "sqlserver"
+        assert sqlserver_conn.source_type == "sqlserver"
+        assert sqlserver_conn.username == "db_user"
+        assert sqlserver_conn.password == "db_password"
+        assert sqlserver_conn.port == "db_port"
+        assert sqlserver_conn.uri == "db_uri"
+        assert sqlserver_conn.database == "db_database"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Hi @vrajat! We would like to use piicatcher with our internal workflows; in order to do that we need to support SQLServer. We have already contributed to dbcat in https://github.com/tokern/dbcat/pull/67, now we would like to make another set of similar changes. 

I see that SQL Server support was removed from piicatcher because [pymssql](https://github.com/pymssql/pymssql) was no longer supported: https://github.com/tokern/piicatcher/pull/74. However, it seems that it is now supported again: https://github.com/pymssql/pymssql/issues/668. So, i would like to add it again if you don't mind. 

 - Added sqlserver support
 - Some tests

Let me know if i can make this PR better! :heart: 